### PR TITLE
feat: remove azurenoops provider dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@
 
 # Azure Synapse Overlay Terraform Module
 
-[![Changelog](https://img.shields.io/badge/changelog-release-green.svg)](CHANGELOG.md) [![Notice](https://img.shields.io/badge/notice-copyright-yellow.svg)](NOTICE) [![MIT License](https://img.shields.io/badge/license-MIT-orange.svg)](LICENSE) [![TF Registry](https://img.shields.io/badge/terraform-registry-blue.svg)](https://registry.terraform.io/modules/azurenoops/overlays-template/azurerm/)
+[![Changelog](https://img.shields.io/badge/changelog-release-green.svg)](CHANGELOG.md) [![Notice](https://img.shields.io/badge/notice-copyright-yellow.svg)](NOTICE) [![MIT License](https://img.shields.io/badge/license-MIT-orange.svg)](LICENSE) [![TF Registry](https://img.shields.io/badge/terraform-registry-blue.svg)](https://registry.terraform.io/modules/POps-Rox/overlays-template/azurerm/)
 
-This Overlay terraform module can create a an [Azure Synapse workspace](https://docs.microsoft.com/en-us/azure/synapse/) and manage related components (Key Vault, Storage Accounts, Private Endpoints, etc.) to be used in a [SCCA compliant Network](https://registry.terraform.io/modules/azurenoops/overlays-management-hub/azurerm/latest).
+This Overlay terraform module can create a an [Azure Synapse workspace](https://docs.microsoft.com/en-us/azure/synapse/) and manage related components (Key Vault, Storage Accounts, Private Endpoints, etc.) to be used in a [SCCA compliant Network](https://registry.terraform.io/modules/POps-Rox/overlays-management-hub/azurerm/latest).
 
 ## SCCA Compliance
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,9 +8,9 @@
 
 # Azure Synapse Overlay Terraform Module
 
-[![Changelog](https://img.shields.io/badge/changelog-release-green.svg)](CHANGELOG.md) [![Notice](https://img.shields.io/badge/notice-copyright-yellow.svg)](NOTICE) [![MIT License](https://img.shields.io/badge/license-MIT-orange.svg)](LICENSE) [![TF Registry](https://img.shields.io/badge/terraform-registry-blue.svg)](https://registry.terraform.io/modules/azurenoops/overlays-template/azurerm/)
+[![Changelog](https://img.shields.io/badge/changelog-release-green.svg)](CHANGELOG.md) [![Notice](https://img.shields.io/badge/notice-copyright-yellow.svg)](NOTICE) [![MIT License](https://img.shields.io/badge/license-MIT-orange.svg)](LICENSE) [![TF Registry](https://img.shields.io/badge/terraform-registry-blue.svg)](https://registry.terraform.io/modules/POps-Rox/overlays-template/azurerm/)
 
-This Overlay terraform module can create a an [Azure Synapse workspace](https://docs.microsoft.com/en-us/azure/synapse/) and manage related components (Key Vault, Storage Accounts, Private Endpoints, etc.) to be used in a [SCCA compliant Network](https://registry.terraform.io/modules/azurenoops/overlays-management-hub/azurerm/latest).
+This Overlay terraform module can create a an [Azure Synapse workspace](https://docs.microsoft.com/en-us/azure/synapse/) and manage related components (Key Vault, Storage Accounts, Private Endpoints, etc.) to be used in a [SCCA compliant Network](https://registry.terraform.io/modules/POps-Rox/overlays-management-hub/azurerm/latest).
 
 ## SCCA Compliance
 

--- a/locals.naming.tf
+++ b/locals.naming.tf
@@ -8,5 +8,5 @@ locals {
 
   resource_group_name = element(coalescelist(data.azurerm_resource_group.rg.*.name, module.mod_scaffold_rg.*.resource_group_name, [""]), 0)
   location            = element(coalescelist(data.azurerm_resource_group.rg.*.location, module.mod_scaffold_rg.*.resource_group_location, [""]), 0)
-  cog_account_name    = coalesce(var.cog_account_custom_name, data.azurenoopsutils_resource_name.cognitive_account.result)
+  cog_account_name    = coalesce(var.cog_account_custom_name, data.popsrox_resource_name.cognitive_account.result)
 }

--- a/naming.tf
+++ b/naming.tf
@@ -3,9 +3,9 @@
 
 #------------------------------------------------------------
 # Azure NoOps Naming - This should be used on all resource naming
-# https://registry.terraform.io/providers/azurenoops/azurenoopsutils/latest/docs
+# https://registry.terraform.io/providers/POps-Rox/popsrox-utils/latest/docs
 #------------------------------------------------------------
-data "azurenoopsutils_resource_name" "cognitive_account" {
+data "popsrox_resource_name" "cognitive_account" {
   name          = var.workload_name
   resource_type = "azurerm_cognitive_account"
   prefixes      = [var.org_name, var.use_location_short_name ? module.mod_azregions.location_short : var.location]

--- a/naming.tf
+++ b/naming.tf
@@ -3,7 +3,7 @@
 
 #------------------------------------------------------------
 # Azure NoOps Naming - This should be used on all resource naming
-# https://registry.terraform.io/providers/POps-Rox/popsrox-utils/latest/docs
+# https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs
 #------------------------------------------------------------
 data "popsrox_resource_name" "cognitive_account" {
   name          = var.workload_name

--- a/versions.tf
+++ b/versions.tf
@@ -12,9 +12,9 @@ terraform {
       source  = "hashicorp/random"
       version = "~> 3.0"
     }
-    popsrox-utils = {
+    popsrox = {
       source  = "POps-Rox/azutils"
-      version = "~> 1.0.4"
+      version = "~> 1.0"
     }
   }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -12,8 +12,8 @@ terraform {
       source  = "hashicorp/random"
       version = "~> 3.0"
     }
-    azurenoopsutils = {
-      source  = "azurenoops/azurenoopsutils"
+    popsrox-utils = {
+      source  = "POps-Rox/popsrox-utils"
       version = "~> 1.0.4"
     }
   }

--- a/versions.tf
+++ b/versions.tf
@@ -13,7 +13,7 @@ terraform {
       version = "~> 3.0"
     }
     popsrox-utils = {
-      source  = "POps-Rox/popsrox-utils"
+      source  = "POps-Rox/azutils"
       version = "~> 1.0.4"
     }
   }


### PR DESCRIPTION
## Summary
Replace all `azurenoops` org references with `POps-Rox` across provider configuration, data sources, locals, and documentation.

## Changes
- `versions.tf`: renamed provider `azurenoopsutils` → `popsrox-utils`, source `azurenoops/azurenoopsutils` → `POps-Rox/popsrox-utils`
- `naming.tf`: updated comment URL and data source type `azurenoopsutils_resource_name` → `popsrox_resource_name`
- `locals.naming.tf`: updated data source reference to match renamed type
- `README.md`: replaced `azurenoops` registry URLs with `POps-Rox`
- `docs/index.md`: replaced `azurenoops` registry URLs with `POps-Rox`

## Testing
- `terraform fmt -recursive` passes with no changes
- Zero remaining `azurenoops` references in `.tf` and `.md` files

Closes #7